### PR TITLE
feat(LogSearch): Add query autosuggest for filters

### DIFF
--- a/backend/app/Http/Controllers/LogController.php
+++ b/backend/app/Http/Controllers/LogController.php
@@ -87,6 +87,7 @@ class LogController extends Controller
                 if (str_contains($part, ':')) {
                     [$key, $value] = explode(':', $part, 2);
                     if (in_array(strtolower($key), $allowedFilters)) {
+                        $value = str_replace('_', ' ', $value);
                         $filters[strtolower($key)] = $value;
                     } else {
                         // If the key is not in allowed filters, return and error response with the allowed filter keys
@@ -203,7 +204,28 @@ class LogController extends Controller
                         foreach ($activeRelationalTags as $tag => $config) {
                             $subQuery->orWhere(function ($typeQuery) use ($config, $filters, $tag) {
                                 $typeQuery->where('EntityTypeId', $config['type_id'])
-                                    ->where('Name', 'LIKE', '%' . $filters[$tag] . '%');
+                                    ->where(function ($nameQuery) use ($filters, $tag) {
+                                        $searchValue = $filters[$tag];
+
+                                        if ($searchValue === '*') {
+                                            $nameQuery->whereNotNull('Name');
+                                            return;
+                                        }
+
+                                        $terms = preg_split('/\s+/', trim($searchValue));
+                                        $terms = array_values(array_filter($terms, static fn($term) => $term !== ''));
+
+                                        foreach ($terms as $term) {
+                                            if ($term === '*') {
+                                                $nameQuery->whereNotNull('Name');
+                                            } elseif (str_contains($term, '*')) {
+                                                $likeValue = str_replace('*', '%', $term);
+                                                $nameQuery->where('Name', 'LIKE', $likeValue);
+                                            } else {
+                                                $nameQuery->where('Name', 'LIKE', '%' . $term . '%');
+                                            }
+                                        }
+                                    });
                             });
                         }
                     });
@@ -234,21 +256,37 @@ class LogController extends Controller
                             if (isset($legacySearchConfigs[$type])) {
                                 $searchData = $legacySearchConfigs[$type];
 
-                                $morphQuery->where(function ($nameQuery) use ($searchData) {
-                                    // Dynamically loop through FirstName, LastName, etc.
-                                    foreach ($searchData['columns'] as $index => $column) {
-                                        // If the value contains a wildcard *, convert it to a LIKE query
-                                        // If it contains ONLY a wildcard (teacher:*) then we want to match any non-null value in that column, so we use "IS NOT NULL" instead of LIKE
-                                        if ($searchData['value'] === '*') {
+                                $searchValue = $searchData['value'];
+
+                                if ($searchValue === '*') {
+                                    $morphQuery->where(function ($nameQuery) use ($searchData) {
+                                        foreach ($searchData['columns'] as $column) {
                                             $nameQuery->orWhereNotNull($column);
-                                        } elseif (str_contains($searchData['value'], '*')) {
-                                            $likeValue = str_replace('*', '%', $searchData['value']);
-                                            $nameQuery->orWhere($column, 'LIKE', $likeValue);
-                                        } else {
-                                            $nameQuery->orWhere($column, 'LIKE', '%' . $searchData['value'] . '%');
                                         }
-                                    }
-                                });
+                                    });
+                                    return;
+                                }
+
+                                $terms = preg_split('/\s+/', trim($searchValue));
+                                $terms = array_values(array_filter($terms, static fn($term) => $term !== ''));
+
+                                foreach ($terms as $term) {
+                                    $morphQuery->where(function ($nameQuery) use ($searchData, $term) {
+                                        // Dynamically loop through FirstName, LastName, etc.
+                                        foreach ($searchData['columns'] as $column) {
+                                            // If the value contains a wildcard *, convert it to a LIKE query
+                                            // If it contains ONLY a wildcard (teacher:*) then we want to match any non-null value in that column, so we use "IS NOT NULL" instead of LIKE
+                                            if ($term === '*') {
+                                                $nameQuery->orWhereNotNull($column);
+                                            } elseif (str_contains($term, '*')) {
+                                                $likeValue = str_replace('*', '%', $term);
+                                                $nameQuery->orWhere($column, 'LIKE', $likeValue);
+                                            } else {
+                                                $nameQuery->orWhere($column, 'LIKE', '%' . $term . '%');
+                                            }
+                                        }
+                                    });
+                                }
                             }
                         });
                     });

--- a/backend/app/Http/Controllers/SuggestionController.php
+++ b/backend/app/Http/Controllers/SuggestionController.php
@@ -2,16 +2,21 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Http\Request;
+use App\Models\School;
+use App\Models\Teacher;
 use App\Models\Pupil;
+use App\Models\Booking;
+use App\Models\Room;
+use App\Models\Equipment;
+use App\Models\Guardian;
 use App\Models\Log;
 
 class SuggestionController extends Controller
 {
     public function index(Request $request)
     {
-        $fields = ['id', 'level', 'category', 'student', 'time', 'date', 'type', 'entity', 'school', 'teacher', 'booking', 'room', 'equipment', 'parent'];
+        $fields = ['id', 'level', 'category', 'time', 'date', 'type', 'entity', 'student', 'school', 'teacher', 'booking', 'room', 'equipment', 'parent'];
         $suggestions = [];
 
         $field = $request->input('field');
@@ -71,6 +76,7 @@ class SuggestionController extends Controller
                     ->pluck('Category')
                     ->toArray();
                 break;
+            //! For now we skip the 'time', 'date', 'type', and 'entity' fields as they are not as relevant for suggestions and would require more complex logic to generate meaningful suggestions
             case 'student':
                 // For the 'student' field, we will return a list of student names as suggestions
                 $suggestions = Pupil::query()
@@ -83,10 +89,78 @@ class SuggestionController extends Controller
                     ->pluck('full_name')
                     ->toArray();
                 break;
-            // TODO: Add more cases for other fields like 'time', 'date', 'type', 'entity', 'school', 'teacher', 'booking', 'room', 'equipment', 'parent'
+            case 'school':
+                // For the 'school' field, we will return a list of school names as suggestions
+                $suggestions = School::query()
+                    ->when(!empty($value), function ($query) use ($value) {
+                        $query->where('School', 'like', $value . '%');
+                    })
+                    ->distinct()
+                    ->limit(10)
+                    ->pluck('School')
+                    ->toArray();
+                break;
+            case 'teacher':
+                // For the 'teacher' field, we will return a list of teacher names as suggestions
+                $suggestions = Teacher::query()
+                    ->when(!empty($value), function ($query) use ($value) {
+                        $query->whereRaw("CONCAT(FirstName, ' ', LastName) LIKE ?", [$value . '%']);
+                    })
+                    ->selectRaw("CONCAT(FirstName, ' ', LastName) AS full_name")
+                    ->distinct()
+                    ->limit(10)
+                    ->pluck('full_name')
+                    ->toArray();
+                break;
+            case 'booking':
+                // For the 'booking' field, we will return a list of booking names as suggestions
+                $suggestions = Booking::query()
+                    ->when(!empty($value), function ($query) use ($value) {
+                        $query->where('Title', 'like', $value . '%');
+                    })
+                    ->distinct()
+                    ->limit(10)
+                    ->pluck('Title')
+                    ->toArray();
+                break;
+            case 'room':
+                // For the 'room' field, we will return a list of room names as suggestions
+                $suggestions = Room::query()
+                    ->when(!empty($value), function ($query) use ($value) {
+                        $query->where('Room', 'like', $value . '%');
+                    })
+                    ->distinct()
+                    ->limit(10)
+                    ->pluck('Room')
+                    ->toArray();
+                break;
+            case 'equipment':
+                // For the 'equipment' field, we will return a list of equipment names as suggestions
+                $suggestions = Equipment::query()
+                    ->when(!empty($value), function ($query) use ($value) {
+                        $query->where('Name', 'like', $value . '%');
+                    })
+                    ->distinct()
+                    ->limit(10)
+                    ->pluck('Name')
+                    ->toArray();
+                break;
+            case 'parent':
+                // For the 'parent' field, we will return a list of guardian names as suggestions
+                $suggestions = Guardian::query()
+                    ->when(!empty($value), function ($query) use ($value) {
+                        $query->whereRaw("CONCAT(FirstName, ' ', LastName) LIKE ?", [$value . '%']);
+                    })
+                    ->selectRaw("CONCAT(FirstName, ' ', LastName) AS full_name")
+                    ->distinct()
+                    ->limit(10)
+                    ->pluck('full_name')
+                    ->toArray();
+                break;
 
             default:
-                $suggestions = []; // For other fields, we can return an empty array or some default suggestions
+                // For other fields, we can return an empty array
+                $suggestions = [];
                 break;
         }
 

--- a/backend/app/Http/Controllers/SuggestionController.php
+++ b/backend/app/Http/Controllers/SuggestionController.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Http\Request;
+use App\Models\Pupil;
+use App\Models\Log;
+
+class SuggestionController extends Controller
+{
+    public function index(Request $request)
+    {
+        $fields = ['id', 'level', 'category', 'student', 'time', 'date', 'type', 'entity', 'school', 'teacher', 'booking', 'room', 'equipment', 'parent'];
+        $suggestions = [];
+
+        $field = $request->input('field');
+        $value = $request->input('value');
+        $field = is_string($field) ? trim($field) : '';
+        $value = is_string($value) ? trim($value) : '';
+        error_log("Received suggestion request for field: $field with value: $value");
+
+        if ($field === '') {
+            $filteredFields = $fields;
+            if ($value !== '') {
+                $filteredFields = array_values(array_filter($fields, function ($suggestion) use ($value) {
+                    return stripos($suggestion, $value) === 0;
+                }));
+            }
+
+            return response()->json(['suggestions' => $filteredFields]);
+        }
+
+        if (!in_array($field, $fields, true)) {
+            return response()->json(['suggestions' => []]);
+        }
+
+        // Now, for each field, we will return a list of suggestions and filter them based on the value
+        switch ($field) {
+            case 'id':
+                // For the 'id' field, we will return a list of the last 10 log IDs as suggestions that match the value (if the value is not empty)
+                $suggestions = Log::query()
+                    ->when(!empty($value), function ($query) use ($value) {
+                        $query->where('LogId', 'like', $value . '%');
+                    })
+                    ->orderBy('LogId', 'desc')
+                    ->limit(10)
+                    ->pluck('LogId')
+                    ->toArray();
+                break;
+            case 'level':
+                // For the 'level' field, we will return a list of log levels as suggestions
+                // The available log levels are from '1' to '5' (1 being the lowest and 5 being the highest)
+                $suggestions = ['1', '2', '3', '4', '5'];
+                // If the value is not empty, we will filter the suggestions based on the value, same array just that it will only return the suggestions that contain the value
+                if (!empty($value)) {
+                    $suggestions = array_filter($suggestions, function ($suggestion) use ($value) {
+                        return strpos($suggestion, $value) === 0;
+                    });
+                    $suggestions = array_values($suggestions);
+                }
+                break;
+            case 'category':
+                // For the 'category' field, we will return a list of log categories as suggestions
+                $suggestions = Log::query()
+                    ->when(!empty($value), function ($query) use ($value) {
+                        $query->where('Category', 'like', $value . '%');
+                    })
+                    ->distinct()
+                    ->limit(10)
+                    ->pluck('Category')
+                    ->toArray();
+                break;
+            case 'student':
+                // For the 'student' field, we will return a list of student names as suggestions
+                $suggestions = Pupil::query()
+                    ->when(!empty($value), function ($query) use ($value) {
+                        $query->whereRaw("CONCAT(FirstName, ' ', LastName) LIKE ?", [$value . '%']);
+                    })
+                    ->selectRaw("CONCAT(FirstName, ' ', LastName) AS full_name")
+                    ->distinct()
+                    ->limit(10)
+                    ->pluck('full_name')
+                    ->toArray();
+                break;
+            // TODO: Add more cases for other fields like 'time', 'date', 'type', 'entity', 'school', 'teacher', 'booking', 'room', 'equipment', 'parent'
+
+            default:
+                $suggestions = []; // For other fields, we can return an empty array or some default suggestions
+                break;
+        }
+
+        // Now just return the suggestion array
+        return response()->json(['suggestions' => $suggestions]);
+    }
+}

--- a/backend/app/Models/PupilHistory.php
+++ b/backend/app/Models/PupilHistory.php
@@ -4,12 +4,12 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
-class Pupil extends Model
+class PupilHistory extends Model
 {
-    protected $table = 'Pupil';  // Matches your DB table name
+    protected $table = 'PupilHistory';  // Matches your DB table name
     protected $primaryKey = 'PupilID';
     public $timestamps = false; // No created_at/updated_at in your table
-    
+
     protected $fillable = [
         'FirstName',
         'LastName',

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -12,3 +12,4 @@ Route::get('/', function () {
 });
 
 Route::get('/logs', [\App\Http\Controllers\LogController::class, 'index']);
+Route::post('/suggestions', [\App\Http\Controllers\SuggestionController::class, 'index']);

--- a/frontend/src/routes/logsView.jsx
+++ b/frontend/src/routes/logsView.jsx
@@ -4,8 +4,25 @@ import { DataTable, AiChat } from '@components/features'
 
 export const LogsViewPage = () => {
     const defaultPerPage = 15
+    const logsDebounceMs = 500
     const [query, setQuery] = useState('')
-    const timeoutRef = useRef(null)
+    const [suggestions, setSuggestions] = useState([])
+    const [showSuggestions, setShowSuggestions] = useState(false)
+    const [highlightedIndex, setHighlightedIndex] = useState(-1)
+    const [suggestionPosition, setSuggestionPosition] = useState({
+        left: 0,
+        top: 0,
+        placement: 'bottom'
+    })
+    const containerRef = useRef(null)
+    const inputRef = useRef(null)
+    const dropdownRef = useRef(null)
+    const logsTimeoutRef = useRef(null)
+    const blurTimeoutRef = useRef(null)
+    const suggestionContextRef = useRef(null)
+    const suggestionRequestIdRef = useRef(0)
+    const suggestionItemRefs = useRef([])
+    const textMeasureCanvasRef = useRef(null)
     const [data, setData] = useState({ rows: [], columns: [] })
     const [pagination, setPagination] = useState({
         current_page: 1,
@@ -40,6 +57,95 @@ export const LogsViewPage = () => {
 
         window.history.replaceState(null, '', url)
     }, [])
+
+    const getSuggestionContext = useCallback((queryValue, cursorPosition) => {
+        const safeQuery = typeof queryValue === 'string' ? queryValue : ''
+        const safeCursor = Number.isInteger(cursorPosition) ? cursorPosition : safeQuery.length
+        const clampedCursor = Math.min(Math.max(safeCursor, 0), safeQuery.length)
+        const textBeforeCursor = safeQuery.slice(0, clampedCursor)
+        const textAfterCursor = safeQuery.slice(clampedCursor)
+        const lastSpaceIndex = textBeforeCursor.lastIndexOf(' ')
+        const nextSpaceIndex = textAfterCursor.indexOf(' ')
+        const startIndex = lastSpaceIndex === -1 ? 0 : lastSpaceIndex + 1
+        const endIndex = nextSpaceIndex === -1 ? safeQuery.length : clampedCursor + nextSpaceIndex
+        const currentSegment = safeQuery.slice(startIndex, endIndex)
+
+        let field = null
+        let value = currentSegment
+
+        if (currentSegment.includes(':')) {
+            const [fieldPart, ...valueParts] = currentSegment.split(':')
+            field = fieldPart
+            value = valueParts.join(':')
+        }
+
+        return {
+            startIndex,
+            endIndex,
+            currentSegment,
+            field,
+            value,
+            cursorPosition: clampedCursor
+        }
+    }, [])
+
+    const measureTextWidth = useCallback((text, font) => {
+        if (!textMeasureCanvasRef.current) {
+            textMeasureCanvasRef.current = document.createElement('canvas')
+        }
+
+        const context = textMeasureCanvasRef.current.getContext('2d')
+        if (!context) return 0
+
+        context.font = font
+        return context.measureText(text).width
+    }, [])
+
+    const updateSuggestionPosition = useCallback(() => {
+        const context = suggestionContextRef.current
+        const input = inputRef.current
+        const container = containerRef.current
+
+        if (!context || !input || !container) return
+
+        const inputRect = input.getBoundingClientRect()
+        const containerRect = container.getBoundingClientRect()
+        const computedStyle = window.getComputedStyle(input)
+        const font = computedStyle.font || `${computedStyle.fontSize} ${computedStyle.fontFamily}`
+        const textBeforeCaret = context.queryValue.slice(0, context.cursorPosition)
+        const textWidth = measureTextWidth(textBeforeCaret, font)
+        const paddingLeft = parseFloat(computedStyle.paddingLeft) || 0
+        const borderLeft = parseFloat(computedStyle.borderLeftWidth) || 0
+        const caretX =
+            inputRect.left + paddingLeft + borderLeft + textWidth - (input.scrollLeft || 0)
+
+        const dropdownWidth = dropdownRef.current?.offsetWidth || 256
+        const dropdownHeight = dropdownRef.current?.offsetHeight || 200
+        const margin = 8
+        const maxLeft = window.innerWidth - dropdownWidth - margin
+        const clampedLeft = Math.min(Math.max(caretX, margin), maxLeft)
+        const relativeLeft = Math.max(
+            0,
+            Math.min(clampedLeft - containerRect.left, containerRect.width - dropdownWidth)
+        )
+
+        const spaceBelow = window.innerHeight - inputRect.bottom
+        let top = inputRect.bottom + margin
+        let placement = 'bottom'
+
+        if (spaceBelow < dropdownHeight + margin) {
+            top = inputRect.top - dropdownHeight - margin
+            placement = 'top'
+        }
+
+        const relativeTop = top - containerRect.top
+
+        setSuggestionPosition({
+            left: relativeLeft,
+            top: relativeTop,
+            placement
+        })
+    }, [measureTextWidth])
 
     const fetchLogs = useCallback(
         async ({ queryValue = '', page = 1, perPage = defaultPerPage } = {}) => {
@@ -94,16 +200,180 @@ export const LogsViewPage = () => {
         [defaultPerPage, updateBrowserUrl]
     )
 
+    const fetchSuggestions = useCallback(
+        async ({ queryValue = '', cursorPosition = null } = {}) => {
+            const apiUrl = new URL('/api/suggestions', 'http://localhost:8000')
+
+            // Get where the user is currently focused in the query input to provide suggestions for that specific tag or value they are typing
+            // To get suggestions we will send a post request with the tag and the value they are currently typing, for example if they are typing "status:erro" we will send { field: "status", value: "erro" } to the backend to get suggestions for the status tag with the value "erro"
+            // It should work even if they are editing in the middle of the query, for example if they have "status:error method:GET" and they are currently editing the "status:error" part, we should still be able to extract that they are editing the "status" tag with the value "error" and provide suggestions for that
+
+            const input = inputRef.current
+            const resolvedCursorPosition = Number.isInteger(cursorPosition)
+                ? cursorPosition
+                : (input?.selectionStart ?? queryValue.length)
+            const context = getSuggestionContext(queryValue, resolvedCursorPosition)
+            suggestionContextRef.current = {
+                ...context,
+                queryValue
+            }
+
+            console.log(`Current segment for suggestions: ${context.currentSegment}`)
+
+            const requestId = ++suggestionRequestIdRef.current
+
+            try {
+                const response = await fetch(apiUrl, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({ field: context.field, value: context.value })
+                })
+
+                if (!response.ok) {
+                    throw new Error(response.statusText || 'Failed to fetch suggestions.')
+                }
+
+                const payload = await response.json()
+                if (suggestionRequestIdRef.current !== requestId) return
+                const nextSuggestions = Array.isArray(payload.suggestions)
+                    ? payload.suggestions
+                    : []
+                setSuggestions(nextSuggestions)
+                console.log('Suggestions:', payload)
+            } catch (fetchError) {
+                console.error('Fetch error:', fetchError)
+                if (suggestionRequestIdRef.current !== requestId) return
+                setSuggestions([])
+            }
+        },
+        [getSuggestionContext]
+    )
+
+    useEffect(() => {
+        if (!showSuggestions || suggestions.length === 0) return
+
+        const frame = requestAnimationFrame(updateSuggestionPosition)
+        window.addEventListener('resize', updateSuggestionPosition)
+        window.addEventListener('scroll', updateSuggestionPosition, true)
+
+        return () => {
+            cancelAnimationFrame(frame)
+            window.removeEventListener('resize', updateSuggestionPosition)
+            window.removeEventListener('scroll', updateSuggestionPosition, true)
+        }
+    }, [showSuggestions, suggestions, updateSuggestionPosition])
+
+    useEffect(() => {
+        if (suggestions.length === 0) {
+            setHighlightedIndex(-1)
+            suggestionItemRefs.current = []
+            return
+        }
+
+        setHighlightedIndex((prev) => (prev >= 0 && prev < suggestions.length ? prev : 0))
+    }, [suggestions])
+
+    useEffect(() => {
+        if (!showSuggestions || highlightedIndex < 0) return
+
+        const item = suggestionItemRefs.current[highlightedIndex]
+        if (item) {
+            item.scrollIntoView({ block: 'nearest' })
+        }
+    }, [highlightedIndex, showSuggestions])
+
+    const handleSuggestionSelect = (suggestion) => {
+        let context = suggestionContextRef.current
+        if (!context || context.queryValue !== query) {
+            const fallbackCursor = inputRef.current?.selectionStart ?? query.length
+            context = {
+                ...getSuggestionContext(query, fallbackCursor),
+                queryValue: query
+            }
+            suggestionContextRef.current = context
+        }
+
+        const isFieldSelection = !context.field
+        const normalizedSuggestion = String(suggestion).replace(/\s+/g, '_')
+        const replacement = isFieldSelection
+            ? `${normalizedSuggestion}:`
+            : `${context.field}:${normalizedSuggestion}`
+        const nextQuery = `${context.queryValue.slice(0, context.startIndex)}${replacement}${context.queryValue.slice(context.endIndex)}`
+        const nextCursor = context.startIndex + replacement.length
+
+        setQuery(nextQuery)
+        setShowSuggestions(isFieldSelection)
+        if (logsTimeoutRef.current) {
+            clearTimeout(logsTimeoutRef.current)
+        }
+        setPagination((prev) => ({ ...prev, current_page: 1 }))
+        fetchLogs({ queryValue: nextQuery, page: 1, perPage: pagination.per_page })
+        if (isFieldSelection) {
+            fetchSuggestions({ queryValue: nextQuery, cursorPosition: nextCursor })
+        } else {
+            suggestionRequestIdRef.current += 1
+            setSuggestions([])
+            setHighlightedIndex(-1)
+        }
+
+        requestAnimationFrame(() => {
+            inputRef.current?.focus()
+            inputRef.current?.setSelectionRange(nextCursor, nextCursor)
+        })
+    }
+
     const onChange = (event) => {
         const value = event.target.value
+        const cursorPosition = event.target.selectionStart ?? value.length
         setQuery(value)
-        if (timeoutRef.current) {
-            clearTimeout(timeoutRef.current)
+        if (value.length === 0) {
+            suggestionRequestIdRef.current += 1
+            setSuggestions([])
+            setHighlightedIndex(-1)
+            suggestionContextRef.current = null
+            setShowSuggestions(true)
+            fetchSuggestions({ queryValue: '', cursorPosition: 0 })
+        } else {
+            setShowSuggestions(true)
+            fetchSuggestions({ queryValue: value, cursorPosition })
         }
-        timeoutRef.current = setTimeout(() => {
+        if (logsTimeoutRef.current) {
+            clearTimeout(logsTimeoutRef.current)
+        }
+        logsTimeoutRef.current = setTimeout(() => {
             setPagination((prev) => ({ ...prev, current_page: 1 }))
             fetchLogs({ queryValue: value, page: 1, perPage: pagination.per_page })
-        }, 500)
+        }, logsDebounceMs)
+    }
+
+    const onKeyDown = (event) => {
+        if (!showSuggestions || suggestions.length === 0) return
+
+        if (event.key === 'ArrowDown') {
+            event.preventDefault()
+            setHighlightedIndex((prev) => (prev + 1) % suggestions.length)
+            return
+        }
+
+        if (event.key === 'ArrowUp') {
+            event.preventDefault()
+            setHighlightedIndex((prev) => (prev <= 0 ? suggestions.length - 1 : prev - 1))
+            return
+        }
+
+        if (event.key === 'Enter') {
+            if (highlightedIndex >= 0 && highlightedIndex < suggestions.length) {
+                event.preventDefault()
+                handleSuggestionSelect(suggestions[highlightedIndex])
+            }
+            return
+        }
+
+        if (event.key === 'Escape') {
+            setShowSuggestions(false)
+        }
     }
 
     const handlePageChange = (nextPage) => {
@@ -120,8 +390,11 @@ export const LogsViewPage = () => {
     useEffect(() => {
         fetchLogs({ queryValue: '', page: 1, perPage: defaultPerPage })
         return () => {
-            if (timeoutRef.current) {
-                clearTimeout(timeoutRef.current)
+            if (logsTimeoutRef.current) {
+                clearTimeout(logsTimeoutRef.current)
+            }
+            if (blurTimeoutRef.current) {
+                clearTimeout(blurTimeoutRef.current)
             }
         }
     }, [defaultPerPage, fetchLogs])
@@ -133,37 +406,113 @@ export const LogsViewPage = () => {
                     AI Logs Analyzer
                 </h2>
 
-                <div
-                    className="border-border bg-secondary focus-within:border-accent flex w-full cursor-text items-center gap-2 rounded border px-3 py-2"
-                    onClick={
-                        // Focus the input when clicking the container
-                        () => {
-                            const input = document.getElementById('queryTextarea')
-                            if (input) input.focus()
+                <div className="relative w-full" ref={containerRef}>
+                    <div
+                        className="border-border bg-secondary focus-within:border-accent flex w-full cursor-text items-center gap-2 rounded border px-3 py-2"
+                        onClick={
+                            // Focus the input when clicking the container
+                            () => {
+                                inputRef.current?.focus()
+                            }
                         }
-                    }
-                >
-                    <Search className="text-metadata h-5 w-5" />
-                    <input
-                        type="text"
-                        value={query}
-                        onChange={onChange}
-                        id="queryTextarea"
-                        className="text-snow placeholder-metadata flex-1 bg-transparent outline-none"
-                        placeholder="Filter by keyword or field"
-                    />
-                    {query && (
-                        <button
-                            onClick={() => {
-                                setQuery('')
-                                setPagination((prev) => ({ ...prev, current_page: 1 }))
-                                fetchLogs({ queryValue: '', page: 1, perPage: pagination.per_page })
+                    >
+                        <Search className="text-metadata h-5 w-5" />
+                        <input
+                            type="text"
+                            ref={inputRef}
+                            value={query}
+                            onChange={onChange}
+                            onKeyDown={onKeyDown}
+                            onFocus={() => {
+                                if (blurTimeoutRef.current) {
+                                    clearTimeout(blurTimeoutRef.current)
+                                }
+                                if (query.length === 0) {
+                                    const cursor = inputRef.current?.selectionStart ?? 0
+                                    setShowSuggestions(true)
+                                    fetchSuggestions({ queryValue: '', cursorPosition: cursor })
+                                }
                             }}
-                            className="text-metadata hover:text-accent flex h-6 w-6 items-center justify-center rounded transition-colors"
-                            title="Clear search"
+                            onBlur={() => {
+                                if (blurTimeoutRef.current) {
+                                    clearTimeout(blurTimeoutRef.current)
+                                }
+                                blurTimeoutRef.current = setTimeout(() => {
+                                    setShowSuggestions(false)
+                                }, 120)
+                            }}
+                            onClick={() => {
+                                requestAnimationFrame(() => {
+                                    const cursor = inputRef.current?.selectionStart ?? query.length
+                                    setShowSuggestions(true)
+                                    fetchSuggestions({ queryValue: query, cursorPosition: cursor })
+                                    updateSuggestionPosition()
+                                })
+                            }}
+                            id="queryTextarea"
+                            className="text-snow placeholder-metadata flex-1 bg-transparent outline-none"
+                            placeholder="Filter by keyword or field"
+                        />
+                        {query && (
+                            <button
+                                onClick={() => {
+                                    setQuery('')
+                                    setPagination((prev) => ({ ...prev, current_page: 1 }))
+                                    fetchLogs({
+                                        queryValue: '',
+                                        page: 1,
+                                        perPage: pagination.per_page
+                                    })
+                                    suggestionRequestIdRef.current += 1
+                                    setSuggestions([])
+                                    setShowSuggestions(false)
+                                    setHighlightedIndex(-1)
+                                    suggestionContextRef.current = null
+                                }}
+                                className="text-metadata hover:text-accent flex h-6 w-6 items-center justify-center rounded transition-colors"
+                                title="Clear search"
+                            >
+                                <X className="h-5 w-5" />
+                            </button>
+                        )}
+                    </div>
+                    {showSuggestions && suggestions.length > 0 && (
+                        <div
+                            ref={dropdownRef}
+                            className="border-border bg-secondary absolute z-20 max-h-60 w-64 overflow-auto rounded border shadow-lg"
+                            style={{
+                                left: `${suggestionPosition.left}px`,
+                                top: `${suggestionPosition.top}px`
+                            }}
+                            data-placement={suggestionPosition.placement}
                         >
-                            <X className="h-5 w-5" />
-                        </button>
+                            <ul className="py-1">
+                                {suggestions.map((suggestion, index) => (
+                                    <li key={`${suggestion}-${index}`}>
+                                        <button
+                                            type="button"
+                                            ref={(node) => {
+                                                suggestionItemRefs.current[index] = node
+                                            }}
+                                            className={`text-snow hover:bg-accent/10 w-full px-3 py-2 text-left ${
+                                                index === highlightedIndex ? 'bg-accent/10' : ''
+                                            }`}
+                                            onMouseDown={(event) => {
+                                                event.preventDefault()
+                                            }}
+                                            onMouseEnter={() => {
+                                                setHighlightedIndex(index)
+                                            }}
+                                            onClick={() => {
+                                                handleSuggestionSelect(suggestion)
+                                            }}
+                                        >
+                                            {String(suggestion)}
+                                        </button>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
                     )}
                 </div>
                 <DataTable


### PR DESCRIPTION
## Overview
Add autosuggest for the log query input with a backend suggestions endpoint to make filter discovery faster.

## Changes

## New Features
- **Query autosuggest UI**: Caret-aware dropdown for tags and values, keyboard navigation, click selection, and inline insertion.
- **Suggestions API**: New /api/suggestions endpoint that returns matching tags and values for log-related fields (id, level, category, student, school, teacher, booking, room, equipment, parent).

## Bug Fixes
- **Query parsing**: Convert underscored multi-term values into space-separated filters.
- **Pupil history model**: Align the PupilHistory model naming with the database table.

## Notes
- Tests not run (not requested).
- Closes #35